### PR TITLE
handle cp4d version in better way

### DIFF
--- a/didact/cp4d-deploy.html
+++ b/didact/cp4d-deploy.html
@@ -78,11 +78,11 @@
                         <p>Deploy selected CP4D services</p>
                         <div id="cp4d-deploy"class="env-config">
                             <label>CP4D Version</label>
-                            <input class="store-data" type="text" id="cp4d_version" value="4.6.0">
+                            <input class="store-data" type="text" id="cp4d_version" value="4.6.3" onkeydown="return (event.keyCode==8 || event.keyCode== 9) ? event.key : /[0-9]|\./i.test(event.key)">
                             <label>CP4D Admin Password</label>
                             <input class="store-data" type="password" id="cp4d_admin_password">
                             <label>CP4D Environment Name</label>
-                            <input class="store-data" type="text" id="cp4d_env_name">
+                            <input class="store-data" type="text" id="cp4d_env_name" value="demo">
                             <label>CP4D Services List</label>
                             <div id="service-list" class="dropdown-check-list" tabindex="100">
                                 <span class="anchor" id="selected-components-string">Select Services</span>

--- a/didact/cp4d-deploy.js
+++ b/didact/cp4d-deploy.js
@@ -8,17 +8,17 @@ currentHTMLstateData = {
     kubeadmin_user: "",
     kubeadmin_pass: "",
     icr_key: "",
-    oc_login:""
+    oc_login: ""
   },
   authenticationOptions: {
     required: ["icr_key"],
     additionalOptions: {
-      "server_option": ["server","api_token"],
-      "kube_option": ["server","kubeadmin_user", "kubeadmin_pass"],
+      "server_option": ["server", "api_token"],
+      "kube_option": ["server", "kubeadmin_user", "kubeadmin_pass"],
       "oc_option": ["oc_login"]
     },
   },
-  validPrerequisites: [["icr_key", "oc_login"],["icr_key", "server", "api_token"], ["icr_key", "server", "kubeadmin_user", "kubeadmin_pass"]],
+  validPrerequisites: [["icr_key", "oc_login"], ["icr_key", "server", "api_token"], ["icr_key", "server", "kubeadmin_user", "kubeadmin_pass"]],
   dropdownIds: ["service-list"],
   envConfigured: false,
   selectedServices: [],
@@ -26,8 +26,9 @@ currentHTMLstateData = {
 }
 
 let previousServicesState = "";
+let previousCP4DVersion = "4.6.3"
 
-function funcLoad(){
+function funcLoad() {
   // Disable timeline
   disableTimelineFromElement("all");
 
@@ -38,15 +39,15 @@ function funcLoad(){
 
   [...document.getElementsByName("authentication-options")].forEach(element => addEventListenerToElement(element, "change", handleAuthenticationOptions))
 
-  addEventListenerToElement(document.getElementById("oc_login"),"input", handleOCLogin)
+  addEventListenerToElement(document.getElementById("oc_login"), "input", handleOCLogin)
   //generate config command
   addEventListenerToElement(document.getElementById("configure-env"), "click", updateConfigVars);
 
   //After env configured successfully enable timeline
-  addEventListenerToElement(document.getElementById("enable-timeline"), "click", enableAll)
+  addEventListenerToElement(document.getElementById("enable-timeline"), "click", updateYamlAndEnableTimeline);
 
   //handle cp4d version
-  addEventListenerToElement(document.getElementById("cp4d_version"),"input", handleCP4dVersion)
+  addEventListenerToElement(document.getElementById("cp4d_version"), "focusout", updateCP4Dyaml)
 
   //open/close logic for all dropdowns
   toggleDropdowns(currentHTMLstateData.dropdownIds)
@@ -76,28 +77,37 @@ function updateConfigVars(e) {
   document.getElementById("configure-env$1").click();
 }
 
-function handleCP4dVersion(e){
-  if((e.target.value.trim()).match((/^\d\.\d$/))){
-    e.target.value = e.target.value.trim() + ".0"
-  }
+function updateYamlAndEnableTimeline(e){
+  updateCP4Dyaml()
+  enableAll()
+}
+
+function handleCP4dVersion(version) {
+  if (version.trim().match((/^\d\.\d\.\d$/)))
+    return version.trim()
+  else if (version.trim().match((/^\d\.\d$/)))
+    return version.trim() + ".0"
+  else
+    return "4.6.3"
 }
 
 function updateCP4Dyaml() {
-  let cp4dVersion = document.getElementById('cp4d_version').value || " ";
+  let cp4dVersion = handleCP4dVersion(document.getElementById('cp4d_version').value);
   let component_list = currentHTMLstateData.selectedServices.toString()
   if (!component_list) {
     component_list = "null"
   }
   let storage = "auto";
-  if (previousServicesState === component_list)
+  if (previousServicesState === component_list && previousCP4DVersion === cp4dVersion)
     return
   document.getElementById("update-config").setAttribute("command", "cd ${CHE_PROJECTS_ROOT}" + `/techzone-demo/olm-utils-v2/;pip3.8 install PyYAML;python3.8 updateYaml.py  ${component_list} ${storage} ${cp4dVersion} cp4d`)
   document.getElementById("update-config").click();
   previousServicesState = component_list;
+  previousCP4DVersion = cp4dVersion;
 }
 
 function install_cpd() {
-  let cp4dVersion = document.getElementById('cp4d_version').value;
+  let cp4dVersion = handleCP4dVersion(document.getElementById('cp4d_version').value);
   let cp4dAdminPassword = document.getElementById('cp4d_admin_password').value
   let cp4dEnvName = document.getElementById('cp4d_env_name').value
   let component_list = currentHTMLstateData.selectedServices.toString()
@@ -105,15 +115,16 @@ function install_cpd() {
     component_list = "null"
   }
   let storage = "auto" //document.getElementById("storage_value").value;
-  document.getElementById("install_cpd$1").setAttribute("command", "cd ${CHE_PROJECTS_ROOT}/techzone-demo/olm-utils-v2;" + `bash deploy.sh cp4d ${cp4dAdminPassword} ${cp4dEnvName}`)
+  document.getElementById("install_cpd$1").setAttribute("command", "cd ${CHE_PROJECTS_ROOT}/techzone-demo/olm-utils-v2;" + `python3.8 updateYaml.py  ${component_list} ${storage} ${cp4dVersion} cp4d;bash deploy.sh cp4d ${cp4dAdminPassword} ${cp4dEnvName}`)
   document.getElementById("install_cpd$1").click();
+  previousCP4DVersion = cp4dVersion;
 }
 
-function getDOMnode(htmlServices, service){
+function getDOMnode(htmlServices, service) {
   let listServices = [...htmlServices].map(service => service.value)
-  for (let i=0; i < listServices.length; i++){
+  for (let i = 0; i < listServices.length; i++) {
     //console.log(htmlServices, service)
-    if(service === listServices[i]){
+    if (service === listServices[i]) {
       return htmlServices[i].parentElement
     }
   }
@@ -138,11 +149,11 @@ function updateSelectedServices(e) {
   let listServices = [...gitServices].map(service => service.value)
   listServices.sort()
   listServices.forEach((res, idx) => {
-    if(currentHTMLstateData.selectedServices.indexOf(res) == -1){
+    if (currentHTMLstateData.selectedServices.indexOf(res) == -1) {
       gitServicesList.appendChild(getDOMnode(gitServices, res))
     }
   })
-    
+
   let showSeleted = document.getElementById("selected-services")
   showSeleted.textContent = currentHTMLstateData.selectedServices.toString().replaceAll(",", ", ")
   document.getElementById("selected-components-string").textContent = getShortenedString(currentHTMLstateData.selectedServices) || "Select Services";
@@ -154,7 +165,7 @@ function filterServiceList(e) {
   let htmlServices = document.getElementsByName("services")
   let listServices = [...htmlServices].map(service => service.value)
   listServices.forEach((res, idx) => {
-    
+
     if (res.toLowerCase().includes(e.target.value.toLowerCase()) || htmlServices[idx].nextSibling.textContent.trim().toLowerCase().includes(e.target.value.toLowerCase())) {
       filteredServices[res] = htmlServices[idx].nextSibling.textContent.trim()
       htmlServices[idx].parentElement.style.display = "block"

--- a/didact/cp4d-deploy.js
+++ b/didact/cp4d-deploy.js
@@ -25,8 +25,10 @@ currentHTMLstateData = {
   doNotRestore: []
 }
 
+const DEFAULT_CP4D_VERSION = "4.6.3"
+
 let previousServicesState = "";
-let previousCP4DVersion = "4.6.3"
+let previousCP4DVersion = DEFAULT_CP4D_VERSION
 
 function funcLoad() {
   // Disable timeline
@@ -82,17 +84,17 @@ function updateYamlAndEnableTimeline(e){
   enableAll()
 }
 
-function handleCP4dVersion(version) {
+function handleCP4DVersion(version) {
   if (version.trim().match((/^\d\.\d\.\d$/)))
     return version.trim()
   else if (version.trim().match((/^\d\.\d$/)))
     return version.trim() + ".0"
   else
-    return "4.6.3"
+    return DEFAULT_CP4D_VERSION
 }
 
 function updateCP4Dyaml() {
-  let cp4dVersion = handleCP4dVersion(document.getElementById('cp4d_version').value);
+  let cp4dVersion = handleCP4DVersion(document.getElementById('cp4d_version').value);
   let component_list = currentHTMLstateData.selectedServices.toString()
   if (!component_list) {
     component_list = "null"
@@ -107,7 +109,7 @@ function updateCP4Dyaml() {
 }
 
 function install_cpd() {
-  let cp4dVersion = handleCP4dVersion(document.getElementById('cp4d_version').value);
+  let cp4dVersion = handleCP4DVersion(document.getElementById('cp4d_version').value);
   let cp4dAdminPassword = document.getElementById('cp4d_admin_password').value
   let cp4dEnvName = document.getElementById('cp4d_env_name').value
   let component_list = currentHTMLstateData.selectedServices.toString()


### PR DESCRIPTION
**Issue** : CP4D version was not getting updated in cp4d-config.yaml also the cp4d version validation was causing bad user experience.

**Things Changed**
1. removed automatic "_.0_" appending to the cp4d version if version was in form of _d.d_ , here d is a digit.
2. version is validated in background without user feedback.
     - only [_0-9_], _._ , _delete_ and _tab_ keys are allowed in cp4d version text field.
     - d.d.d is valid version
     - d.d is treated as  d.d.0
     - any other format is invalid and default version 4.6.3 is used
4. cp4d-config.yaml is updated with cp4d version on cluster if cp4d was already installed.
5. cp4d version text field changes are directly updated in yaml and vice versa.
6. cp4d-config.yaml is updated once again on install with all the selected fields in html for safety.